### PR TITLE
Implicitly wrap the logger message in a closure.

### DIFF
--- a/Example/View Controllers/LocationViewController.swift
+++ b/Example/View Controllers/LocationViewController.swift
@@ -35,7 +35,7 @@ import UIKit
 class LocationViewController: UIViewController {
 
     /// Simple log handler that subclasses can use with their `GeoLocator` instance.
-    static let logHandler: Geode.GeoLocator.LogHandler = { message, level, file, line in
+    static let logHandler: Geode.GeoLocator.LogHandler = { (_ message: @autoclosure () -> String, _ level: GeoLocator.LogLevel, _ file: StaticString, _ line: UInt) in
         debugPrint("[GEODE] \(String(describing: level).uppercased()) \(file) L\(line): \(message())")
     }
 

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ is `nil` by default. This allows for easy integration with existing logging
 frameworks (e.g. [CocoaLumberjack](https://github.com/CocoaLumberjack/CocoaLumberjack)).
 
 ```swift
-public typealias LogHandler = (_ message: () -> String, _ level: LogLevel, _ file: StaticString, _ line: UInt) -> Void
+public typealias LogHandler = (_ message: @autoclosure () -> String, _ level: LogLevel, _ file: StaticString, _ line: UInt) -> Void
 ```
 
 The `message` parameter is passed as a closure, which allows us to potentially
@@ -130,7 +130,7 @@ avoid any unnecessary string processing if the log level is not set high enough.
 A simple logging implementation might look like the following:
 
 ```swift
-locator.logHandler = { message, level, file, line in
+locator.logHandler = { (_ message: @autoclosure () -> String, _ level: LogLevel, _ file: StaticString, _ line: UInt) in
     debugPrint("[GEODE] \(String(describing: level).uppercased()) \(file) L\(line): \(message())")
 }
 ```

--- a/Source/GeoLocator.swift
+++ b/Source/GeoLocator.swift
@@ -39,7 +39,7 @@ open class GeoLocator: NSObject {
     public typealias LocationUpdateHandler = (CLLocation) -> Void
 
     /// A closure that logs messages.
-    public typealias LogHandler = (_ message: () -> String, _ level: LogLevel, _ file: StaticString, _ line: UInt) -> Void
+    public typealias LogHandler = (_ message: @autoclosure () -> String, _ level: LogLevel, _ file: StaticString, _ line: UInt) -> Void
 
     /**
      The `GeoLocator`'s mode of operation.
@@ -242,11 +242,11 @@ extension GeoLocator: CLLocationManagerDelegate {
             return
         }
 
-        log({ "location updated: \(newLocation.coordinate)" }, level: .verbose)
+        log("location updated: \(newLocation.coordinate)", level: .verbose)
 
         let locationAge = abs(newLocation.timestamp.timeIntervalSinceNow)
         if mode == .continuous && locationAge > maxLocationAge || newLocation.horizontalAccuracy < 0.0 {
-            log({ "ignoring old location" }, level: .info)
+            log("ignoring old location", level: .info)
             return
         }
 
@@ -267,10 +267,10 @@ extension GeoLocator: CLLocationManagerDelegate {
         if let code = CLError.Code(rawValue: error._code), error._domain == kCLErrorDomain {
             switch code {
             case .locationUnknown:
-                log({"Unknown location"}, level: .error)
+                log("Unknown location", level: .error)
 
             case .denied:
-                log({"User has denied location access"}, level: .error)
+                log("User has denied location access", level: .error)
                 stopMonitoring()
 
             default:
@@ -288,7 +288,7 @@ extension GeoLocator: CLLocationManagerDelegate {
     // MARK: Responding to Authorization Changes
 
     public func locationManager(_ manager: CLLocationManager, didChangeAuthorization status: CLAuthorizationStatus) {
-        log({ "authorization status changed to \(status)"}, level: .verbose)
+        log("authorization status changed to \(status)", level: .verbose)
 
         switch status {
         case .authorizedAlways, .authorizedWhenInUse:
@@ -329,7 +329,7 @@ extension GeoLocator: CLLocationManagerDelegate {
 
 private extension GeoLocator {
 
-    func log(_ message: () -> String, level: LogLevel, file: StaticString = #file, line: UInt = #line) {
+    func log(_ message: @autoclosure () -> String, level: LogLevel, file: StaticString = #file, line: UInt = #line) {
         logHandler?(message, level, file, line)
     }
 


### PR DESCRIPTION
The only downside to the `@autoclosure` syntax seems to be that we lose type inference on the concrete signature in `LocationViewController` and have to copy the full type alias.

Things could be worse.
